### PR TITLE
Update pypdfium2 code

### DIFF
--- a/SL_ArabicOCR.py
+++ b/SL_ArabicOCR.py
@@ -95,18 +95,18 @@ if __name__ == '__main__':
 
         if pdf_input is not None:
             f_name = "OCR_" + pdf_input.name[:-4]
-            #pdff = PyPDF2.PdfFileReader(open(pdf_input.read(), "rb"))
+            pdf_input.seek(0)
+            pdf = pdfium.PdfDocument(pdf_input.read())
             if t != "":
                 num_of_pages = int(t)
             else:
-                num_of_pages = 1
+                num_of_pages = len(pdf)
             print(num_of_pages)
-            with pdfium.PdfDocument(pdf_input) as pdf:
-                renderer = pdf.render_topil(
-                    page_indices = list(range(num_of_pages)),
-                    greyscale = True,
-                )
-                images += list(renderer)
+            renderer = pdf.render_topil(
+                page_indices = list(range(num_of_pages)),
+                greyscale = True,
+            )
+            images += list(renderer)
         else:
             f_name = "OCR_" + img_input.name[:-4]
             pil_img = Image.open(img_input)

--- a/SL_ArabicOCR.py
+++ b/SL_ArabicOCR.py
@@ -102,8 +102,7 @@ if __name__ == '__main__':
                 num_of_pages = 1
             print(num_of_pages)
             with pdfium.PdfDocument(pdf_input) as pdf:
-                page_indices = list( range(num_of_pages) )
-                renderer = pdf.render_topil(page_indices=page_indices)
+                renderer = pdf.render_topil(page_indices=list(range(num_of_pages)))
                 images += list(renderer)
         else:
             f_name = "OCR_" + img_input.name[:-4]

--- a/SL_ArabicOCR.py
+++ b/SL_ArabicOCR.py
@@ -14,7 +14,6 @@ from reportlab.lib.enums import TA_RIGHT
 import re
 import os
 import pypdfium2 as pdfium
-from pdf2image import convert_from_path
 from bidi.algorithm import get_display
 import arabic_reshaper
 from reportlab.pdfbase.ttfonts import TTFont
@@ -23,11 +22,11 @@ from reportlab.pdfbase import pdfmetrics
 from reportlab.lib.pagesizes import letter
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 import pytesseract
-from pdf2image import convert_from_path
+#rom pdf2image import convert_from_path
 import streamlit as st
 import base64
 from base64 import b64encode
-import PyPDF2
+#mport PyPDF2
 from PIL import Image, ImageOps
 
 #print("hello to streamlit")
@@ -102,10 +101,10 @@ if __name__ == '__main__':
             else:
                 num_of_pages = 1
             print(num_of_pages)
-            with pdfium.PdfContext(pdf_input) as pdf:
-                for page in range(num_of_pages):
-                    image = pdfium.render_page_topil(pdf, page)
-                    images.append(image)
+            with pdfium.PdfDocument(pdf_input) as pdf:
+                page_indices = list( range(num_of_pages) )
+                renderer = pdf.render_topil(page_indices=page_indices)
+                images += list(renderer)
         else:
             f_name = "OCR_" + img_input.name[:-4]
             pil_img = Image.open(img_input)

--- a/SL_ArabicOCR.py
+++ b/SL_ArabicOCR.py
@@ -26,7 +26,7 @@ import pytesseract
 import streamlit as st
 import base64
 from base64 import b64encode
-#mport PyPDF2
+#import PyPDF2
 from PIL import Image, ImageOps
 
 #print("hello to streamlit")

--- a/SL_ArabicOCR.py
+++ b/SL_ArabicOCR.py
@@ -102,7 +102,10 @@ if __name__ == '__main__':
                 num_of_pages = 1
             print(num_of_pages)
             with pdfium.PdfDocument(pdf_input) as pdf:
-                renderer = pdf.render_topil(page_indices=list(range(num_of_pages)))
+                renderer = pdf.render_topil(
+                    page_indices = list(range(num_of_pages)),
+                    greyscale = True,
+                )
                 images += list(renderer)
         else:
             f_name = "OCR_" + img_input.name[:-4]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ reportlab
 numpy
 docx2pdf
 pypdfium2>=2
-pdf2image
+#pdf2image
 opencv-python
 arabic_reshaper
 pytesseract
 python-docx
 python-bidi
-PyPDF2==2.10.0
+#PyPDF2==2.10.0
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 reportlab
 numpy
 docx2pdf
-pypdfium2==1.0.0
+pypdfium2>=2
 pdf2image
 opencv-python
 arabic_reshaper


### PR DESCRIPTION
Changes:
* Switch to more recent pypdfium2 API.
* Use pypdfium2's faster multipage renderer which processes pages concurrently.
* Render in greyscale mode.
* Comment out unused imports (PyPDF2 and pdf2image).

PS: If you like, you can also default to all pages, rather than just the first page. You may get the number of pages with `len(pdf)`, where `pdf` is a `pdfium.PdfDocument` object.